### PR TITLE
feat: configure monorepo workspace structure (fixes #32)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -43,6 +43,7 @@
 - Keep code short; commits semantic.
 - Reusable logic in `src/lib/utils/shared.ts` or `src/lib/utils/server.ts`.
 - Use `tsx` scripts for migrations.
+- Use sequintial thinking before starting to code
 
 ## Build & Git Updates
 - After all changes, ALWAYS build the project with `npm run build`. Ignore warnings, fix errors.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# enZo Frontend
+# enZo Project
+
+A monorepo containing the enZo project applications and shared packages.
+
+## Structure
+
+```
+.
+├── apps/
+│   ├── web/          # Next.js frontend application
+│   └── strapi/       # Strapi 5 backend application
+└── packages/
+    └── shared/       # Shared code and utilities
+```
+
+## Development
+
+This project uses Turborepo for monorepo management. Common commands:
+
+```bash
+# Install dependencies
+npm install
+
+# Development
+npm run dev
+
+# Build
+npm run build
+
+# Lint
+npm run lint
+
+# Test
+npm run test
+```
+
+## Requirements
+
+- Node.js >= 18.0.0
+- npm >= 10.2.4

--- a/apps/strapi/README.md
+++ b/apps/strapi/README.md
@@ -1,0 +1,10 @@
+# Strapi Backend
+
+This directory contains the Strapi 5 backend application for the enZo project.
+
+## Structure
+
+- Uses Strapi 5
+- SQLite for development
+- PostgreSQL for staging/production
+- Code-based content types in `src/api/<content-type>/content-types/<content-type>/schema.json` 

--- a/apps/strapi/package.json
+++ b/apps/strapi/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@enzo/strapi",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "echo 'Strapi dev script placeholder'",
+    "build": "echo 'Strapi build script placeholder'",
+    "test": "echo 'Strapi test script placeholder'",
+    "lint": "echo 'Strapi lint script placeholder'",
+    "clean": "rm -rf .cache build node_modules"
+  },
+  "dependencies": {
+    "@enzo/shared": "*"
+  }
+} 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,10 @@
+# Web Application
+
+This directory contains the Next.js frontend application for the enZo project.
+
+## Structure
+
+- Uses Next.js 14+ with App Router
+- TypeScript for type safety
+- Tailwind CSS for styling
+- Client components with `"use client"` directive when needed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@enzo/web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "echo 'Web dev script placeholder'",
+    "build": "echo 'Web build script placeholder'",
+    "test": "echo 'Web test script placeholder'",
+    "lint": "echo 'Web lint script placeholder'",
+    "clean": "rm -rf .next .turbo node_modules"
+  },
+  "dependencies": {
+    "@enzo/shared": "*"
+  }
+} 

--- a/instructions/start-issue.md
+++ b/instructions/start-issue.md
@@ -27,6 +27,11 @@ Always list the issues with the following command(Dont use the tool):
   ```
 
   and then checkout the branch:
+  first always pull main and merge it into your branch:
+  ```bash
+  git pull origin main
+  ```
+  then checkout the branch:
   ```bash
   git checkout <type>/<description>-<issue-number>
   ```
@@ -47,9 +52,23 @@ Always list the issues with the following command(Dont use the tool):
 
 - **Commit with Conventional Message and Issue Reference:**
 
-- **Verify Build and Tests:**
 
-## 5. Create PR & Complete
+## 5. Check the acceptance criteria and Definition of Done 
+  retrieve the issue and check the acceptance criteria and Definition of Done 
+  ```bash
+  gh issue view <issue-number>
+  ```
+
+  fix the issues and make sure all acceptance criteria are met and the Definition of Done is completed.
+
+  when you think you are done try 5 again untill you get no issues.
+
+## 6. Verify Build and Tests
+
+## 7. Push to Branch
+
+
+## 8. Create PR & Complete
 
 - **Create Pull Request Linked to Issue:**
   ```bash
@@ -63,6 +82,8 @@ Always list the issues with the following command(Dont use the tool):
   ```bash
   ./scripts/github/project.sh status stefa93 <project-number> <issue-number> "Done"
   ```
+
+## 9. Delete Branch
 
 ## Reference
 

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4,6 +4,32 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
+    "apps/strapi": {
+      "name": "@enzo/strapi",
+      "version": "0.1.0",
+      "dependencies": {
+        "@enzo/shared": "*"
+      }
+    },
+    "apps/web": {
+      "name": "@enzo/web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@enzo/shared": "*"
+      }
+    },
+    "node_modules/@enzo/shared": {
+      "resolved": "packages/shared",
+      "link": true
+    },
+    "node_modules/@enzo/strapi": {
+      "resolved": "apps/strapi",
+      "link": true
+    },
+    "node_modules/@enzo/web": {
+      "resolved": "apps/web",
+      "link": true
+    },
     "node_modules/prettier": {
       "version": "3.5.1",
       "dev": true,
@@ -46,6 +72,26 @@
       "os": [
         "darwin"
       ]
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/shared": {
+      "name": "@enzo/shared",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,32 @@
         "node": ">=18.0.0"
       }
     },
+    "apps/strapi": {
+      "name": "@enzo/strapi",
+      "version": "0.1.0",
+      "dependencies": {
+        "@enzo/shared": "*"
+      }
+    },
+    "apps/web": {
+      "name": "@enzo/web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@enzo/shared": "*"
+      }
+    },
+    "node_modules/@enzo/shared": {
+      "resolved": "packages/shared",
+      "link": true
+    },
+    "node_modules/@enzo/strapi": {
+      "resolved": "apps/strapi",
+      "link": true
+    },
+    "node_modules/@enzo/web": {
+      "resolved": "apps/web",
+      "link": true
+    },
     "node_modules/prettier": {
       "version": "3.5.1",
       "dev": true,
@@ -126,6 +152,26 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/shared": {
+      "name": "@enzo/shared",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      }
     }
   }
 }

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,10 @@
+# Shared Packages
+
+This directory contains shared code and utilities used across the enZo project applications.
+
+## Structure
+
+- TypeScript for type safety
+- Shared types in `src/lib/types.ts`
+- Reusable utilities in `src/lib/utils/`
+- Shared components (if needed) 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@enzo/shared",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": ["dist/**"],
+  "scripts": {
+    "build": "tsc",
+    "test": "echo 'Shared test script placeholder'",
+    "lint": "echo 'Shared lint script placeholder'",
+    "clean": "rm -rf dist node_modules"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+} 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,8 @@
+// Shared package exports will go here
+export const placeholder = 'shared';
+
+// Type exports
+export * from './lib/types';
+
+// Utility exports
+export * from './lib/utils/shared'; 

--- a/packages/shared/src/lib/types.ts
+++ b/packages/shared/src/lib/types.ts
@@ -1,0 +1,12 @@
+// Common type definitions shared between applications
+export interface BaseEntity {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Example shared type - remove or modify as needed
+export interface User extends BaseEntity {
+  email: string;
+  name: string;
+} 

--- a/packages/shared/src/lib/utils/shared.ts
+++ b/packages/shared/src/lib/utils/shared.ts
@@ -1,0 +1,8 @@
+// Shared utility functions
+export const formatDate = (date: Date): string => {
+  return date.toISOString();
+};
+
+export const isValidEmail = (email: string): boolean => {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}; 

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "strict": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+} 


### PR DESCRIPTION
Implements monorepo workspace structure with proper path references and shared package setup. Changes: - Created apps directory with web and strapi subdirectories - Created packages directory with shared package - Set up proper package.json files with workspace dependencies - Added TypeScript configuration for shared package - Added example shared types and utilities - Configured proper path references between packages